### PR TITLE
Explicitly use python2 (PEP 394)

### DIFF
--- a/alive/tools/verify.py
+++ b/alive/tools/verify.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import logging, logging.config, argparse, sys
 import os

--- a/infer.py
+++ b/infer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from alive.tools.infer import main
 

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from alive.tools.verify import main
 

--- a/tests/lit/lit.py
+++ b/tests/lit/lit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 if __name__=='__main__':
     import lit

--- a/tests/lit/lit/ProgressBar.py
+++ b/tests/lit/lit/ProgressBar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Source: http://code.activestate.com/recipes/475116/, with
 # modifications by Daniel Dunbar.

--- a/tests/lit/lit/formats/alivetest.py
+++ b/tests/lit/lit/formats/alivetest.py
@@ -43,7 +43,7 @@ class AliveTest(FileBasedTest):
 
   def execute(self, test, litConfig):
     test = test.getSourcePath()
-    cmd = ['python', 'run.py', test]
+    cmd = ['python2', 'run.py', test]
     input = readFile(test)
 
     # add test-specific args

--- a/tests/lit/lit/main.py
+++ b/tests/lit/lit/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 lit - LLVM Integrated Tester.


### PR DESCRIPTION
`python` links to `python3` on some distributions (e.g. Arch Linux).